### PR TITLE
compatibility issue: os.chmod

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 toml==0.9.4
 prompt_toolkit==2.0.3
 requests==2.13.0
-stellar_base==0.1.6
+stellar_base==0.1.8.1
 PyQRCode==1.2.1

--- a/stcli.py
+++ b/stcli.py
@@ -44,7 +44,7 @@ def load_conf():
             unzip()
     if not os.path.isfile(PTC):
         create_conf()
-    os.chmod(PTC, 0700)
+    os.chmod(PTC, 0o700)
     with open(PTC, 'r') as fp:
         CONF = toml.loads(fp.read())
 
@@ -53,14 +53,14 @@ def unzip():
 
 
 def zipfile(passw):
-    os.chmod(PTC, 0700)
+    os.chmod(PTC, 0o700)
     if os.path.isfile(PTZ):
         cmd = "zip -u --password %s -m %s %s" % (passw, PTZ, PTC)
     else:
         cmd = "zip --password %s -m %s %s" % (passw, PTZ, PTC)
     print('zip --password ******* -m %s %s' % (PTZ, PTC))
     os.system(cmd)
-    os.chmod(PTZ, 0700)
+    os.chmod(PTZ, 0o700)
 
 
 def set_private_key():
@@ -78,7 +78,7 @@ def set_private_key():
     #print(CONF)
     with open(PTC, 'w') as fp:
         fp.write(toml.dumps(CONF))
-    os.chmod(PTC, 0700)
+    os.chmod(PTC, 0o700)
 
 
 def create_conf():
@@ -86,7 +86,7 @@ def create_conf():
         fp.write('public_key = ""\nprivate_key = ""\nnetwork = "TESTNET"\nlanguage ' +
                  '= "ENGLISH"\nstellar_address = ""\nairdrop="t"\npartner_key=""\n')
     load_conf()
-    os.chmod(PTC, 0700)
+    os.chmod(PTC, 0o700)
     return
 
 


### PR DESCRIPTION
1. os.chmod(FILE, 0700) does not work in Python3, use os.chmod(FILE, 0o700) instead
2. Could not find a version that satisfies the requirement stellar_base==0.1.6, so I changed it to 0.1.8.1

Thanks.